### PR TITLE
Populated remainder of sections for tutorial doc

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -4,7 +4,7 @@ This tutorial will take you through a step by step guide to building, deploying 
 
 ## Background
 
-### Greeter contract
+### [Greeter contract](https://github.com/PaulRBerg/hardhat-template)
 
 The Greeter contract is a very simple smart contract that allows user to write a greeting message on the blockchain.
 
@@ -28,3 +28,87 @@ Envio is a framework for developing a backend to index and aggregate blockchain 
 npm i -g envio
 ```
 
+## Start a Greeter project
+`cd` into your project directory and run `envio init` command.
+Then choose `Greeter` template and a language of choice to define the Event Handler.
+
+This will auto-generate the setup files required for generating the indexing code.
+More information on the setup files can be found in [Envio documentation](https://docs.envio.dev/docs/overview)
+
+## Start a docker container
+In order to run the indexer locally, you will need to spin up a docker container for:
+- postGres server
+- Ganache (local blockchain)
+
+First open Docker Desktop.
+
+You can first remove any stale data in docker by running:
+```bash
+docker-compose down -v
+```
+
+Then restart the docker by running:
+```bash
+docker-compose up -d
+```
+
+## Auto-generate indexing files
+Now you are ready to generate the files required for indexing, by running:
+```bash
+envio codegen
+```
+
+This will auto-generate all the indexing files, as per specifications outline in the setup files.
+All indexing files are written in Rescript, and they **do not** need to be modified to run the indexer.
+
+## Deploy the smart contract onto ganache using HardHat
+Copy *contracts* folder into your project folder.
+`cd` into *contracts* and change the name of `.env.example` file to `.env`.
+
+Follow instructions below:
+```
+cd contracts
+rm -r -f deployments
+pnpm hardhat deploy
+```
+Note that this will delete the previous deployment of the smart contract and re-deploy to prevent `node synced status` errors.
+
+Check that the address of the deployment aligns with the address of smart contract in the `config.yaml` file, and if not, make sure they are the same.
+
+More information on how to deploy contracts using Hardhat can be found [here](https://hardhat.org/hardhat-runner/docs/guides/deploying).
+
+## Starting the indexer
+Start the indexer by running:
+```
+pnpm start
+```
+
+## Running tasks
+`task:setGreeting` will create a greeting for a user.
+
+This task will require an account for the user [1-10] and a greeting string and can be called by running the following:
+```bash
+cd contracts
+pnpm hardhat task:setGreeting --account "#" --greeting "Hola"
+```
+
+`task:clearGreeting` will clear the latest greeting for a user.
+
+This task only requires the account of user to be passed and can be called by running the following:
+```bash
+cd contracts
+pnpm hardhat task:clearGreeting --account "#"
+```
+
+## Viewing the results
+
+To view the data in the database, run
+```bash
+./generated/register_tables_with_hasura.sh
+```
+
+Navigate to http://localhost:8080/console to view local Hasura.
+
+Admin-secret for Hasura is `testing` 
+
+Alternatively you can open the file `index.html` for a cleaner experience (no Hasura stuff). Unfortunately, Hasura is currently not configured to make the data public.


### PR DESCRIPTION
Populated remainder of the tutorial doc so that user can follow end-to-end.

Tested the entire workflow with Javascript and following all the steps in sequence worked.
The idea is that user will just use the existing Greeter template and hence there is no need to change the config, schema or the event handlers

Some notes:
1. running `docker compose up -d` in project folder doesn't spin up Ganache -> check this in codegen folder
2. needed to change `.env.example` to `.env` in order to deploy contracts onto Ganache